### PR TITLE
add geth / go-ethereum

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,9 @@ Wallets
  * Stellar Lumen
  * Ripple
 
+Nodes
+==========
+ * geth/go-ethereum
 
 Download
 ========

--- a/recipes-nodes/geth/geth_1.8.27.bb
+++ b/recipes-nodes/geth/geth_1.8.27.bb
@@ -1,0 +1,17 @@
+SUMMARY = "Official Go implementation of the Ethereum protocol"
+DESCRIPTION = "geth is the command line interface for running a full ethereum node implemented in Go."
+HOMEPAGE = "https://geth.ethereum.org"
+LICENSE = "LGPLv3"
+LIC_FILES_CHKSUM = "file://${COMMON_LICENSE_DIR}/GPL-3.0;md5=c79ff39f19dfec6d293b95dea7b07891"
+
+SRC_URI = "git://github.com/ethereum/go-ethereum.git;branch=release/1.8;tag=v${PV}"
+
+inherit go
+
+GO_IMPORT = "github.com/ethereum/go-ethereum"
+GO_LINKSHARED = ""
+PTEST_ENABLED = "0"
+
+LDFLAGS += "-lpthread"
+
+RDEPENDS_${PN}-dev += " gawk bash"


### PR DESCRIPTION
I've been working on a meta-ethereum layer:
https://github.com/bernardoaraujor/meta-ethereum

My plan was to write recipes for:
- geth/go-ethereum
- aleth/cpp-ethereum
- parity

However aleth uses CMake's Hunter for handling dependencies, which made BitBake integration not straightforward at all. The aleth-dev branch of meta-ethereum is a huge mess because of that.

On the other hand, rust support is still not 100% on OE. I tried writing a recipe for parity using meta-rust and meta-rust-bin, but got into a lot of trouble and also gave up.

In the end, geth was the only successful recipe. Since I don't plan on spending more time on meta-ethereum, I guess it's a good idea to put geth here :)

Might be worth trying to bump it up to 1.9